### PR TITLE
fix: implement getCurrentThrowableError for InfiniteQuery

### DIFF
--- a/.changeset/free-things-dream.md
+++ b/.changeset/free-things-dream.md
@@ -1,0 +1,5 @@
+---
+"mobx-tanstack-query": patch
+---
+
+fix the start method of InfiniteQuery

--- a/src/inifinite-query.ts
+++ b/src/inifinite-query.ts
@@ -504,6 +504,11 @@ export class InfiniteQuery<
     return Query.prototype.createQueryHash.call(this, queryKey, options);
   }
 
+  protected getCurrentThrowableError(options?: RefetchOptions) {
+    // @ts-expect-error
+    return Query.prototype.getCurrentThrowableError.call(this, options);
+  }
+
   setData(
     updater: Updater<
       NoInfer<InfiniteData<TQueryFnData, TPageParam>> | undefined,


### PR DESCRIPTION
Hi! I found an interesting bug.
When calling InfinityQuery.start(), the error 'getCurrentThrowableError is undefine' occurred. (InfiniteQuery doesn't implement getCurrentThrowableError.)

Here's my proposed solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error retrieval for infinite queries to make throwable errors accessible.

* **Bug Fixes**
  * Fixed start behavior for infinite queries to resolve a stability issue.

* **Tests**
  * Added coverage for infinite-query start scenarios, including normal execution and error handling.

* **Chores**
  * Added a changeset recording a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->