### PR TITLE
[feature!] Changed the `result` behavior after `destroy()` / abort.

### DIFF
--- a/.changeset/fair-dolphins-remain.md
+++ b/.changeset/fair-dolphins-remain.md
@@ -1,0 +1,10 @@
+---
+"mobx-tanstack-query": major
+---
+
+Changed the `result` behavior after `destroy()` / abort.
+
+Previously, a destroyed query instance kept returning its last locally observed `_result`.
+Now, when `result` is read after destroy/abort, it is computed via `queryObserver.getOptimisticResult(this.options)`, so it reflects the latest cache snapshot for the last `queryKey` without restoring subscriptions.
+
+This is a breaking change for consumers and tests that relied on the old "frozen result after destroy" behavior.

--- a/docs/api/Query.md
+++ b/docs/api/Query.md
@@ -299,6 +299,12 @@ Query original result (The same as returns the [`useQuery` hook](https://tanstac
 The badge reflects the **default**: the internal `_result` field is decorated as deep observable. You can change the MobX flavour (`ref`, `shallow`, `struct`, `true`, or `false`) with the [`resultObservable`](#resultobservable-queryfeature) query feature.
 :::
 
+::: warning `result` after `destroy()` or abort
+After `destroy()` is called or the [`abortSignal`](#abortsignal-option) is aborted, reading `result` does **not** keep returning the last locally observed in-memory snapshot from before teardown. Instead, it is computed with `queryObserver.getOptimisticResult(this.options)`: you get the **current cache snapshot** for the last `queryKey`, and subscriptions are **not** restored.
+
+If you relied on a fixed “last seen” result after destroy (for example in tests or cleanup code), snapshot the fields you need before `destroy()` / abort, or avoid reading `result` after teardown.
+:::
+
 ### `setData(updater, options)`
 
 Set data for current query (Uses [queryClient.setQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetquerydata))
@@ -509,6 +515,8 @@ const query = new Query(queryClient, () => ({
 // Clean up the query
 query.destroy();
 ```
+
+See also: [`result`](#result-queryobserverresult) after `destroy()` or abort.
 
 ## Built-in Features
 

--- a/src/base-query.ts
+++ b/src/base-query.ts
@@ -392,6 +392,9 @@ export abstract class BaseQuery<
       }
       this.update({} as TUpdateOptions);
     }
+    if (this.abortController.signal.aborted && this._result) {
+      return this.queryObserver.getOptimisticResult(this.options);
+    }
     return this._result || this.queryObserver.getCurrentResult();
   }
 

--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -2099,31 +2099,31 @@ describe('Query', () => {
       await sleep(10);
       expect(query1.result).toStrictEqual({
         ...query1.result,
-        data: undefined,
-        dataUpdatedAt: 0,
+        data: 'bar',
+        dataUpdatedAt: query1.result.dataUpdatedAt,
         error: null,
         errorUpdateCount: 0,
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
-        isFetched: false,
-        isFetchedAfterMount: false,
-        isFetching: true,
-        isInitialLoading: true,
-        isLoading: true,
+        isFetched: true,
+        isFetchedAfterMount: true,
+        isFetching: false,
+        isInitialLoading: false,
+        isLoading: false,
         isLoadingError: false,
         isPaused: false,
-        isPending: true,
+        isPending: false,
         isPlaceholderData: false,
         isRefetchError: false,
         isRefetching: false,
         isStale: true,
-        isSuccess: false,
+        isSuccess: true,
         promise: query1.result.promise,
         refetch: query1.result.refetch,
-        status: 'pending',
+        status: 'success',
       });
       expect(query2.result).toStrictEqual({
         ...query2.result,
@@ -2156,31 +2156,31 @@ describe('Query', () => {
       await sleep(10);
       expect(query1.result).toStrictEqual({
         ...query1.result,
-        data: undefined,
-        dataUpdatedAt: 0,
+        data: 'bar',
+        dataUpdatedAt: query1.result.dataUpdatedAt,
         error: null,
         errorUpdateCount: 0,
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
-        isFetched: false,
-        isFetchedAfterMount: false,
-        isFetching: true,
-        isInitialLoading: true,
-        isLoading: true,
+        isFetched: true,
+        isFetchedAfterMount: true,
+        isFetching: false,
+        isInitialLoading: false,
+        isLoading: false,
         isLoadingError: false,
         isPaused: false,
-        isPending: true,
+        isPending: false,
         isPlaceholderData: false,
         isRefetchError: false,
         isRefetching: false,
         isStale: true,
-        isSuccess: false,
+        isSuccess: true,
         promise: query1.result.promise,
         refetch: query1.result.refetch,
-        status: 'pending',
+        status: 'success',
       });
     });
 
@@ -2216,13 +2216,13 @@ describe('Query', () => {
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
         isFetched: false,
         isFetchedAfterMount: false,
-        isFetching: true,
-        isInitialLoading: true,
-        isLoading: true,
+        isFetching: false,
+        isInitialLoading: false,
+        isLoading: false,
         isLoadingError: false,
         isPaused: false,
         isPending: true,
@@ -2273,13 +2273,13 @@ describe('Query', () => {
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
         isFetched: false,
         isFetchedAfterMount: false,
-        isFetching: true,
-        isInitialLoading: true,
-        isLoading: true,
+        isFetching: false,
+        isInitialLoading: false,
+        isLoading: false,
         isLoadingError: false,
         isPaused: false,
         isPending: true,
@@ -2330,13 +2330,13 @@ describe('Query', () => {
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
         isFetched: false,
         isFetchedAfterMount: false,
-        isFetching: true,
-        isInitialLoading: true,
-        isLoading: true,
+        isFetching: false,
+        isInitialLoading: false,
+        isLoading: false,
         isLoadingError: false,
         isPaused: false,
         isPending: true,
@@ -2373,6 +2373,7 @@ describe('Query', () => {
     });
 
     it('after abort signal for inprogress success work query create new instance with the same key and it should work', async () => {
+      vi.useFakeTimers();
       const abortController1 = new LinkedAbortController();
       const query = new QueryMock({
         queryFn: async () => {
@@ -2391,6 +2392,8 @@ describe('Query', () => {
         abortSignal: abortController1.signal,
         queryKey: ['test', 'key'] as const,
       });
+
+      await vi.advanceTimersByTimeAsync(0);
 
       expect(query.result).toMatchObject({
         status: 'pending',
@@ -2420,26 +2423,34 @@ describe('Query', () => {
 
       abortController1.abort();
 
-      await sleep(10);
+      await vi.advanceTimersByTimeAsync(20);
 
       expect(query.result).toMatchObject({
-        status: 'pending',
-        fetchStatus: 'fetching',
-        isPending: true,
-        isSuccess: false,
+        status: 'success',
+        fetchStatus: 'idle',
+        isPending: false,
+        isSuccess: true,
         isError: false,
-        isInitialLoading: true,
-        isLoading: true,
-        data: undefined,
-        dataUpdatedAt: 0,
+        isInitialLoading: false,
+        isLoading: false,
+        data: {
+          foo: 1,
+          bar: 2,
+          kek: {
+            pek: {
+              tek: 1,
+            },
+          },
+        },
+        dataUpdatedAt: query.result.dataUpdatedAt,
         error: null,
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
         errorUpdateCount: 0,
-        isFetched: false,
-        isFetchedAfterMount: false,
-        isFetching: true,
+        isFetched: true,
+        isFetchedAfterMount: true,
+        isFetching: false,
         isRefetching: false,
         isLoadingError: false,
         isPaused: false,
@@ -2456,33 +2467,41 @@ describe('Query', () => {
         queryKey: ['test', 'key'] as const,
       });
 
-      await sleep(10);
+      await vi.advanceTimersByTimeAsync(20);
 
       expect(query.result).toMatchObject({
-        status: 'pending',
-        fetchStatus: 'fetching',
-        isPending: true,
-        isSuccess: false,
+        status: 'success',
+        fetchStatus: 'idle',
+        isPending: false,
+        isSuccess: true,
         isError: false,
-        isInitialLoading: true,
-        isLoading: true,
-        data: undefined,
-        dataUpdatedAt: 0,
+        isInitialLoading: false,
+        isLoading: false,
+        data: {
+          foo: 1,
+          bar: 2,
+          kek: {
+            pek: {
+              tek: 1,
+            },
+          },
+        },
+        dataUpdatedAt: query.result.dataUpdatedAt,
         error: null,
         errorUpdatedAt: 0,
         failureCount: 0,
         failureReason: null,
         errorUpdateCount: 0,
-        isFetched: false,
-        isFetchedAfterMount: false,
-        isFetching: true,
+        isFetched: true,
+        isFetchedAfterMount: true,
+        isFetching: false,
         isRefetching: false,
         isLoadingError: false,
         isPaused: false,
         isPlaceholderData: false,
         isRefetchError: false,
         isStale: true,
-      } satisfies Partial<QueryObserverResult<string>>);
+      } satisfies Partial<QueryObserverResult<any>>);
 
       expect(query2.result).toMatchObject({
         status: 'success',
@@ -2504,6 +2523,11 @@ describe('Query', () => {
         isFetching: false,
         isRefetching: false,
       });
+
+      vi.useRealTimers();
+
+      query2.destroy();
+      query.destroy();
     });
 
     it('after aborted Query with failed queryFn - create new Query with the same key and it should has succeed execution', async () => {
@@ -2606,12 +2630,12 @@ describe('Query', () => {
         data: undefined,
         dataUpdatedAt: 0,
         error: null,
-        errorUpdateCount: 1,
+        errorUpdateCount: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
-        isFetched: true,
+        isFetched: false,
         isStale: true,
         isSuccess: false,
         isPending: true,
@@ -2645,6 +2669,335 @@ describe('Query', () => {
         isSuccess: true,
         isPending: false,
       } satisfies Partial<QueryObserverResult<any, any>>);
+    });
+
+    it('should sync two queries to the same queryKey via options and keep shared data', async () => {
+      vi.useFakeTimers();
+
+      const queryClient = new QueryClient({});
+      queryClient.mount();
+
+      const firstKeyPart = observable.box('first');
+      const secondKeyPart = observable.box('second');
+
+      const firstQuery = new QueryMock(
+        {
+          queryFn: async () => {
+            await sleep(100);
+            return 'foo';
+          },
+          options: () => ({
+            queryKey: ['shared-key-test', firstKeyPart.get()] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const secondQuery = new QueryMock(
+        {
+          queryFn: async () => {
+            await sleep(200);
+            return 'bar';
+          },
+          options: () => ({
+            queryKey: ['shared-key-test', secondKeyPart.get()] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const firstObserverDisposer = reaction(
+        () => firstQuery.result.data,
+        () => {},
+        {
+          fireImmediately: true,
+        },
+      );
+      const secondObserverDisposer = reaction(
+        () => secondQuery.result.data,
+        () => {},
+        { fireImmediately: true },
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('foo');
+      expect(secondQuery.result.data).toBe('bar');
+
+      runInAction(() => {
+        firstKeyPart.set('merged');
+      });
+      await vi.runAllTimersAsync();
+
+      runInAction(() => {
+        secondKeyPart.set('merged');
+      });
+      await vi.runAllTimersAsync();
+
+      // Первая query остается подписанной на общий ключ и получает итоговое значение "bar".
+      expect(firstQuery.result.data).toBe('bar');
+      // Вторая query активна и также получает итоговое значение по общему ключу.
+      expect(secondQuery.result.data).toBe('bar');
+      expect(firstQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+      expect(secondQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+
+      firstObserverDisposer();
+      secondObserverDisposer();
+      firstQuery.destroy();
+      secondQuery.destroy();
+      queryClient.unmount();
+    });
+
+    it('should sync two queries to the same queryKey and destroy second query before its queryFn completion', async () => {
+      vi.useFakeTimers();
+
+      const queryClient = new QueryClient({});
+      queryClient.mount();
+
+      const firstKeyPart = observable.box('first');
+      const secondKeyPart = observable.box('second');
+
+      const firstQuery = new QueryMock(
+        {
+          queryFn: async () => {
+            await sleep(100);
+            return 'foo';
+          },
+          options: () => ({
+            queryKey: ['shared-key-test-destroy', firstKeyPart.get()] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const secondQuery = new QueryMock(
+        {
+          queryFn: async () => {
+            await sleep(200);
+            return 'bar';
+          },
+          options: () => ({
+            queryKey: ['shared-key-test-destroy', secondKeyPart.get()] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const firstObserverDisposer = reaction(
+        () => firstQuery.result.data,
+        () => {},
+        {
+          fireImmediately: true,
+        },
+      );
+      const secondObserverDisposer = reaction(
+        () => secondQuery.result.data,
+        () => {},
+        { fireImmediately: true },
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('foo');
+      expect(secondQuery.result.data).toBe('bar');
+
+      runInAction(() => {
+        firstKeyPart.set('merged');
+      });
+      await vi.runAllTimersAsync();
+
+      runInAction(() => {
+        secondKeyPart.set('merged');
+      });
+      await vi.advanceTimersByTimeAsync(100);
+
+      secondQuery.destroy();
+
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('bar');
+      // После destroy() подписка отключена, но при чтении result берется optimistic snapshot по последнему queryKey.
+      expect(secondQuery.result.data).toBe('bar');
+      expect(firstQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+      expect(secondQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+
+      firstObserverDisposer();
+      secondObserverDisposer();
+      firstQuery.destroy();
+      queryClient.unmount();
+    });
+
+    it('should sync two lazy queries to the same queryKey via options and keep shared data', async () => {
+      vi.useFakeTimers();
+      const queryClient = new QueryClient({});
+      queryClient.mount();
+
+      const firstKeyPart = observable.box('first');
+      const secondKeyPart = observable.box('second');
+
+      const firstQuery = new QueryMock(
+        {
+          lazy: true,
+          queryFn: async () => {
+            await sleep(100);
+            return 'foo';
+          },
+          options: () => ({
+            queryKey: ['shared-key-test-lazy', firstKeyPart.get()] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const secondQuery = new QueryMock(
+        {
+          lazy: true,
+          queryFn: async () => {
+            await sleep(200);
+            return 'bar';
+          },
+          options: () => ({
+            queryKey: ['shared-key-test-lazy', secondKeyPart.get()] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const firstObserverDisposer = reaction(
+        () => firstQuery.result.data,
+        () => {},
+        {
+          fireImmediately: true,
+        },
+      );
+      const secondObserverDisposer = reaction(
+        () => secondQuery.result.data,
+        () => {},
+        { fireImmediately: true },
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('foo');
+      expect(secondQuery.result.data).toBe('bar');
+
+      runInAction(() => {
+        firstKeyPart.set('merged');
+      });
+      await vi.runAllTimersAsync();
+
+      runInAction(() => {
+        secondKeyPart.set('merged');
+      });
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('bar');
+      expect(secondQuery.result.data).toBe('bar');
+      expect(firstQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+      expect(secondQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+
+      firstObserverDisposer();
+      secondObserverDisposer();
+      firstQuery.destroy();
+      secondQuery.destroy();
+      queryClient.unmount();
+
+      vi.useRealTimers();
+    });
+
+    it('should sync two lazy queries to the same queryKey and destroy second query before its queryFn completion', async () => {
+      vi.useFakeTimers();
+      const queryClient = new QueryClient({});
+      queryClient.mount();
+
+      const firstKeyPart = observable.box('first');
+      const secondKeyPart = observable.box('second');
+
+      const firstQuery = new QueryMock(
+        {
+          lazy: true,
+          queryFn: async () => {
+            await sleep(100);
+            return 'foo';
+          },
+          options: () => ({
+            queryKey: [
+              'shared-key-test-lazy-destroy',
+              firstKeyPart.get(),
+            ] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const secondQuery = new QueryMock(
+        {
+          lazy: true,
+          queryFn: async () => {
+            await sleep(200);
+            return 'bar';
+          },
+          options: () => ({
+            queryKey: [
+              'shared-key-test-lazy-destroy',
+              secondKeyPart.get(),
+            ] as const,
+            enabled: true,
+          }),
+        },
+        queryClient,
+      );
+
+      const firstObserverDisposer = reaction(
+        () => firstQuery.result.data,
+        () => {},
+        {
+          fireImmediately: true,
+        },
+      );
+      const secondObserverDisposer = reaction(
+        () => secondQuery.result.data,
+        () => {},
+        { fireImmediately: true },
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('foo');
+      expect(secondQuery.result.data).toBe('bar');
+
+      runInAction(() => {
+        firstKeyPart.set('merged');
+      });
+      await vi.runAllTimersAsync();
+
+      runInAction(() => {
+        secondKeyPart.set('merged');
+      });
+      await vi.advanceTimersByTimeAsync(100);
+
+      secondQuery.destroy();
+
+      await vi.runAllTimersAsync();
+
+      expect(firstQuery.result.data).toBe('bar');
+      expect(secondQuery.result.data).toBe('bar');
+      expect(firstQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+      expect(secondQuery.spies.queryFn).toHaveBeenCalledTimes(2);
+
+      firstObserverDisposer();
+      secondObserverDisposer();
+      firstQuery.destroy();
+      queryClient.unmount();
+
+      vi.useRealTimers();
     });
 
     it('after aborted Query with failed queryFn - create new Query with the same key and it should has succeed execution (+ abort signal usage inside query fn)', async () => {
@@ -2748,12 +3101,12 @@ describe('Query', () => {
         data: undefined,
         dataUpdatedAt: 0,
         error: null,
-        errorUpdateCount: 1,
+        errorUpdateCount: 0,
         failureCount: 0,
         failureReason: null,
-        fetchStatus: 'fetching',
+        fetchStatus: 'idle',
         isError: false,
-        isFetched: true,
+        isFetched: false,
         isStale: true,
         isSuccess: false,
         isPending: true,


### PR DESCRIPTION

Previously, a destroyed query instance kept returning its last locally observed `_result`.
Now, when `result` is read after destroy/abort, it is computed via `queryObserver.getOptimisticResult(this.options)`, so it reflects the latest cache snapshot for the last `queryKey` without restoring subscriptions.

This is a breaking change for consumers and tests that relied on the old "frozen result after destroy" behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Query result behavior after destruction or abortion has changed. Results now reflect the latest cache state instead of retaining the previously frozen snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->